### PR TITLE
remove jpegtran-bin and yarn

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -67,12 +67,10 @@ RUN npm install -g \
       imagemin-svgo \
       img-optim \
       jpegoptim-bin \
-      jpegtran-bin \
       optipng-bin \
       pngcrush-bin \
       pngquant-bin \
       svgo \
-      yarn \
     --unsafe-perm=true \
     --allow-root
 


### PR DESCRIPTION
The docker image (now?) has jpegtran-bin and yarn by default and we don't have to npm install them. Doing so, was breaking the build. This seem to fix it.

Ref https://github.com/Open-Historical-Map-Labs/openhistoricalmap-docker/issues/22

cc @batpad @danrademacher 